### PR TITLE
Jb44604

### DIFF
--- a/src/libs/installer/component.cpp
+++ b/src/libs/installer/component.cpp
@@ -589,13 +589,14 @@ void Component::loadUserInterfaces(const QDir &directory, const QStringList &uis
 
 /*!
   Loads the text of the licenses contained in \a licenseHash from \a directory.
-  This is saved into a new hash containing the filename and the text of that file.
+  This is saved into a new hash containing the filename, the text and the priority of that file.
 */
 void Component::loadLicenses(const QString &directory, const QHash<QString, QVariant> &licenseHash)
 {
     QHash<QString, QVariant>::const_iterator it;
     for (it = licenseHash.begin(); it != licenseHash.end(); ++it) {
-        const QString &fileName = it.value().toString();
+        QVariantMap license = it.value().toMap();
+        const QString &fileName = license.value(QLatin1String("file")).toString();
 
         if (!ProductKeyCheck::instance()->isValidLicenseTextFile(fileName))
             continue;
@@ -629,7 +630,8 @@ void Component::loadLicenses(const QString &directory, const QHash<QString, QVar
         }
         QTextStream stream(&file);
         stream.setCodec("UTF-8");
-        d->m_licenses.insert(it.key(), qMakePair(fileName, stream.readAll()));
+        license.insert(QLatin1String("content"), stream.readAll());
+        d->m_licenses.insert(it.key(), license);
     }
 }
 
@@ -645,9 +647,9 @@ QStringList Component::userInterfaces() const
 }
 
 /*!
-    Returns a hash that contains the file names and text of license files for the component.
+    Returns a hash that contains the file names, text and priorities of license files for the component.
 */
-QHash<QString, QPair<QString, QString> > Component::licenses() const
+QHash<QString, QVariantMap> Component::licenses() const
 {
     return d->m_licenses;
 }
@@ -913,9 +915,9 @@ OperationList Component::operations() const
             d->m_licenseOperation->setValue(QLatin1String("component"), name());
 
             QVariantMap licenses;
-            const QList<QPair<QString, QString> > values = d->m_licenses.values();
+            const QList<QVariantMap> values = d->m_licenses.values();
             for (int i = 0; i < values.count(); ++i)
-                licenses.insert(values.at(i).first, values.at(i).second);
+                licenses.insert(values.at(i).value(QLatin1String("file")).toString(), values.at(i).value(QLatin1String("content")));
             d->m_licenseOperation->setValue(QLatin1String("licenses"), licenses);
             d->m_operations.append(d->m_licenseOperation);
         }

--- a/src/libs/installer/component.h
+++ b/src/libs/installer/component.h
@@ -138,7 +138,7 @@ public:
     void markAsPerformedInstallation();
 
     QStringList userInterfaces() const;
-    QHash<QString, QPair<QString, QString> > licenses() const;
+    QHash<QString, QVariantMap> licenses() const;
     Q_INVOKABLE QWidget *userInterface(const QString &name) const;
     Q_INVOKABLE virtual void beginInstallation();
     Q_INVOKABLE virtual void createOperations();

--- a/src/libs/installer/component_p.h
+++ b/src/libs/installer/component_p.h
@@ -76,7 +76,7 @@ public:
     QHash<QString, QPointer<QWidget> > m_userInterfaces;
 
     // < display name, < file name, file content > >
-    QHash<QString, QPair<QString, QString> > m_licenses;
+    QHash<QString, QVariantMap> m_licenses;
     QList<QPair<QString, bool> > m_pathsForUninstallation;
 };
 

--- a/src/libs/installer/packagemanagergui.h
+++ b/src/libs/installer/packagemanagergui.h
@@ -278,7 +278,8 @@ private Q_SLOTS:
     void currentItemChanged(QListWidgetItem *current);
 
 private:
-    void addLicenseItem(const QHash<QString, QPair<QString, QString> > &hash);
+    void addLicenseItem(const QHash<QString, QVariantMap> &hash);
+    void createLicenseWidgets();
     void updateUi();
 
 private:
@@ -290,6 +291,8 @@ private:
 
     QLabel *m_acceptLabel;
     QLabel *m_rejectLabel;
+
+    QHash<QString, QVariantMap> m_licenseItems;
 };
 
 

--- a/src/libs/kdtools/updatesinfo.cpp
+++ b/src/libs/kdtools/updatesinfo.cpp
@@ -129,8 +129,13 @@ bool UpdatesInfoData::parsePackageUpdateElement(const QDomElement &updateE)
                 const QDomNode licenseNode = licenseNodes.at(i);
                 if (licenseNode.nodeName() == QLatin1String("License")) {
                     QDomElement element = licenseNode.toElement();
-                    licenseHash.insert(element.attributeNode(QLatin1String("name")).value(),
-                        element.attributeNode(QLatin1String("file")).value());
+                    QVariantMap attributes;
+                    attributes.insert(QLatin1String("file"), element.attributeNode(QLatin1String("file")).value());
+                    if (!element.attributeNode(QLatin1String("priority")).isNull())
+                        attributes.insert(QLatin1String("priority"), element.attributeNode(QLatin1String("priority")).value());
+                    else
+                        attributes.insert(QLatin1String("priority"), QLatin1String("0"));
+                    licenseHash.insert(element.attributeNode(QLatin1String("name")).value(), attributes);
                 }
             }
             if (!licenseHash.isEmpty())


### PR DESCRIPTION
Arrange LicenseAgreementPage licenses and filter duplicates
- Add a "priority" attribute to the "License" element used in "package.xml"
  for arranging licenses by priority in the LicenseAgreementPage. Priority >0
  shows the license on top of others.
- Arrange the licenses with the same priority alphabetically
- Filter duplicate licenses from the LicenseAgreementPage