### PR TITLE
Fix uninstaller for archives extracted to subfolder of target dir

### DIFF
--- a/src/libs/kdtools/updateoperation.cpp
+++ b/src/libs/kdtools/updateoperation.cpp
@@ -496,6 +496,10 @@ bool UpdateOperation::fromXml(const QDomDocument &doc)
                 }
                 var = QVariant::fromValue(list);
             }
+        } else if (t == QVariant::String) {
+              const QString str = QInstaller::replacePath(value,
+                        QLatin1String(QInstaller::scRelocatable), target);
+              var = QVariant::fromValue(str);
         }
 
         m_values[name] = var;


### PR DESCRIPTION
ExtractArchiveOperation::readDataFileContents replaces
@RELOCATABLE_PATH@ with the targetDir when determining the location
of the data file. Usually this works fine, as the targetDir was
replaced with @RELOCATABLE_PATH@ when writing maintenance config files.
However, the targetDir in that context is the target of the whole
installation, not the extracted package. If the package is extracted to
a subdirectory of the installation targetDir, the result is not correct.
Pre-emptively replacing targetDir with @RELOCATABLE_PATH@ keeps the
result in control of ExtractArchiveOperation.